### PR TITLE
修复 README 中的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=erma0/douyin&type=Date)](https://star-history.com/#erma0/douyin&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=erma0/douyin&type=Date)](https://star-history.dera.page/#erma0/douyin&Date)


### PR DESCRIPTION
README 中的 Star History 图表目前无法正常加载，因为原服务受 GitHub API 限制已经失效。本 PR 将图表链接更新为可用的新服务地址，恢复 Star History 图表的显示，感谢对项目一直以来的支持。